### PR TITLE
Add error constants

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Version History
 ===============
 
+- 0.2.0 - released *2016-06-06*
+
+  - exported constants from pycares.errno
+
 - 0.1.0 - released *2016-04-27*
 
   - initial version

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = ['pycares>=1,<2', 'tornado>=4.0']
 tests_require = ['nose', 'mock', 'codecov', 'coverage']
 
 setuptools.setup(name='tdns',
-                 version='0.1.0',
+                 version='0.2.0',
                  description='An asynchronous Tornado wrapper for pycares',
                  long_description=open('README.rst').read(),
                  author='Gavin M. Roy',

--- a/tdns.py
+++ b/tdns.py
@@ -7,7 +7,7 @@ An asynchronous Tornado pycares DNS client wrapper, exporting the full API.
 from tornado import concurrent
 from tornado import ioloop
 
-import pycares
+import pycares.errno
 
 __version__ = '0.1.0'
 
@@ -46,7 +46,32 @@ __all__ = ['Channel',
            'ARES_NI_LOOKUPSERVICE',
            'ARES_NI_IDN',
            'ARES_NI_IDN_ALLOW_UNASSIGNED',
-           'ARES_NI_IDN_USE_STD3_ASCII_RULES']
+           'ARES_NI_IDN_USE_STD3_ASCII_RULES'
+           'ARES_SUCCESS',
+           'ARES_ENODATA',
+           'ARES_EFORMERR',
+           'ARES_ESERVFAIL',
+           'ARES_ENOTFOUND',
+           'ARES_ENOTIMP',
+           'ARES_EREFUSED',
+           'ARES_EBADQUERY',
+           'ARES_EBADNAME',
+           'ARES_EBADFAMILY',
+           'ARES_EBADRESP',
+           'ARES_ECONNREFUSED',
+           'ARES_ETIMEOUT',
+           'ARES_EOF',
+           'ARES_EFILE',
+           'ARES_ENOMEM',
+           'ARES_EDESTRUCTION',
+           'ARES_EBADSTR',
+           'ARES_EBADFLAGS',
+           'ARES_ENONAME',
+           'ARES_EBADHINTS',
+           'ARES_ENOTINITIALIZED',
+           'ARES_ELOADIPHLPAPI',
+           'ARES_EADDRGETNETWORKPARAMS',
+           'ARES_ECANCELLED']
 
 AresError = pycares.AresError
 
@@ -87,6 +112,34 @@ ARES_NI_LOOKUPSERVICE = pycares.ARES_NI_LOOKUPSERVICE
 ARES_NI_IDN = pycares.ARES_NI_IDN
 ARES_NI_IDN_ALLOW_UNASSIGNED = pycares.ARES_NI_IDN_ALLOW_UNASSIGNED
 ARES_NI_IDN_USE_STD3_ASCII_RULES = pycares.ARES_NI_IDN_USE_STD3_ASCII_RULES
+
+# export pycares.errno constants too
+
+ARES_SUCCESS = pycares.errno.ARES_SUCCESS
+ARES_ENODATA = pycares.errno.ARES_ENODATA
+ARES_EFORMERR = pycares.errno.ARES_EFORMERR
+ARES_ESERVFAIL = pycares.errno.ARES_ESERVFAIL
+ARES_ENOTFOUND = pycares.errno.ARES_ENOTFOUND
+ARES_ENOTIMP = pycares.errno.ARES_ENOTIMP
+ARES_EREFUSED = pycares.errno.ARES_EREFUSED
+ARES_EBADQUERY = pycares.errno.ARES_EBADQUERY
+ARES_EBADNAME = pycares.errno.ARES_EBADNAME
+ARES_EBADFAMILY = pycares.errno.ARES_EBADFAMILY
+ARES_EBADRESP = pycares.errno.ARES_EBADRESP
+ARES_ECONNREFUSED = pycares.errno.ARES_ECONNREFUSED
+ARES_ETIMEOUT = pycares.errno.ARES_ETIMEOUT
+ARES_EOF = pycares.errno.ARES_EOF
+ARES_EFILE = pycares.errno.ARES_EFILE
+ARES_ENOMEM = pycares.errno.ARES_ENOMEM
+ARES_EDESTRUCTION = pycares.errno.ARES_EDESTRUCTION
+ARES_EBADSTR = pycares.errno.ARES_EBADSTR
+ARES_EBADFLAGS = pycares.errno.ARES_EBADFLAGS
+ARES_ENONAME = pycares.errno.ARES_ENONAME
+ARES_EBADHINTS = pycares.errno.ARES_EBADHINTS
+ARES_ENOTINITIALIZED = pycares.errno.ARES_ENOTINITIALIZED
+ARES_ELOADIPHLPAPI = pycares.errno.ARES_ELOADIPHLPAPI
+ARES_EADDRGETNETWORKPARAMS = pycares.errno.ARES_EADDRGETNETWORKPARAMS
+ARES_ECANCELLED = pycares.errno.ARES_ECANCELLED
 
 
 def reverse_address(ip_address):

--- a/tdns.py
+++ b/tdns.py
@@ -143,7 +143,11 @@ class Channel(object):
 
     def __del__(self):  # pragma: no cover
         """Destroy the channel when deleting the object instance."""
-        self._channel.destroy()
+        try:
+            self._channel.destroy()
+        except pycares.AresError as e:
+            # raised when the channel has never been used
+            pass
 
     def gethostbyname(self, name, family):
         """Retrieves host information corresponding to a host name from a host

--- a/tdns.py
+++ b/tdns.py
@@ -9,7 +9,7 @@ from tornado import ioloop
 
 import pycares.errno
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 __all__ = ['Channel',
            'AresError'

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import socket
+import unittest
 
 from tornado import testing
 
@@ -66,3 +67,12 @@ class ChannelTests(testing.AsyncTestCase):
     def test_servers(self):
         self.channel.servers = ['4.4.4.4', '4.4.8.8']
         self.assertEqual(self.channel.servers, ['4.4.4.4', '4.4.8.8'])
+
+
+class ConstantExportTests(unittest.TestCase):
+
+    def test_that_top_level_constants_are_enumerated(self):
+        for name in dir(pycares):
+            if name.startswith(('QUERY_TYPE_', 'ARES_FLAG_', 'ARES_NI_')):
+                self.assertEqual(getattr(tdns, name),
+                                 getattr(pycares, name))

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@ import socket
 import unittest
 
 from tornado import testing
+import pycares.errno
 
 import tdns
 
@@ -76,3 +77,9 @@ class ConstantExportTests(unittest.TestCase):
             if name.startswith(('QUERY_TYPE_', 'ARES_FLAG_', 'ARES_NI_')):
                 self.assertEqual(getattr(tdns, name),
                                  getattr(pycares, name))
+
+    def test_that_errno_constants_are_enumerated(self):
+        for name in dir(pycares.errno):
+            if name.startswith('ARES_'):
+                self.assertEqual(getattr(tdns, name),
+                                 getattr(pycares.errno, name))


### PR DESCRIPTION
This PR exposes additional constants from the `pycares.errno` module.  I added tests to verify that we are exporting all of the constants as well.
